### PR TITLE
Initialism replacer

### DIFF
--- a/templ.go
+++ b/templ.go
@@ -11,11 +11,11 @@ import (
 var (
 	types map[string]struct{}
 
-	attr = "{{ define \"Attr\" }}{{ printf \"  %s \" (title .Name) }}{{ printf \"%s `xml:\\\"%s,attr\\\"`\" .Type .Name }}\n{{ end }}"
+	attr = "{{ define \"Attr\" }}{{ printf \"  %s \" (title .Name) }}{{ printf \"%s `xml:\\\"%s,attr\\\"`\" (lintName .Type) .Name }}\n{{ end }}"
 
-	child = "{{ define \"Child\" }}{{ printf \"  %s \" (title .Name) }}{{ if .List }}[]{{ end }}{{ printf \"%s `xml:\\\"%s\\\"`\" .FieldType .Name }}\n{{ end }}"
+	child = "{{ define \"Child\" }}{{ printf \"  %s \" (title .Name) }}{{ if .List }}[]{{ end }}{{ printf \"%s `xml:\\\"%s\\\"`\" (lintName .FieldType) .Name }}\n{{ end }}"
 
-	cdata = "{{ define \"Cdata\" }}{{ printf \"%s %s `xml:\\\",chardata\\\"`\\n\" (title .Name) .Type }}{{ end }}"
+	cdata = "{{ define \"Cdata\" }}{{ printf \"%s %s `xml:\\\",chardata\\\"`\\n\" (title .Name) (lintName .Type) }}{{ end }}"
 
 	elem = `{{ define "Elem" }}{{ printf "type %s struct {\n" (assimilate .Name) }}{{ range $a := .Attribs }}{{ template "Attr" $a }}{{ end }}{{ range $c := .Children }}{{ template "Child" $c }}{{ end }} {{ if .Cdata }}{{ template "Cdata" . }}{{ end }} }
 	{{ end }}`
@@ -24,7 +24,8 @@ var (
 `
 
 	fmap = template.FuncMap{
-		"title":      strings.Title,
+		"lintName":   lintName,
+		"title":      title,
 		"assimilate": assimilate,
 	}
 
@@ -93,9 +94,9 @@ func assimilate(name string) string {
 		for i := 1; i < len(s); i++ {
 			s[i] = strings.Title(s[i])
 		}
-		return strings.Join(s, "")
+		return lintName(strings.Join(s, ""))
 	}
-	return name
+	return lintName(name)
 }
 
 func generateGo(out io.Writer, roots []*xmlElem) {

--- a/templ.go
+++ b/templ.go
@@ -86,7 +86,7 @@ func primitive(e *xmlElem) bool {
 	}
 
 	switch e.Type {
-	case "bool", "string", "int", "float64":
+	case "bool", "string", "int", "float64", "time.Time":
 		return true
 	}
 	return false

--- a/templ.go
+++ b/templ.go
@@ -29,6 +29,50 @@ var (
 	}
 
 	tt *template.Template
+
+	// The initialism pairs are based on the commonInitialisms found in golang/lint
+	// https://github.com/golang/lint/blob/4946cea8b6efd778dc31dc2dbeb919535e1b7529/lint.go#L698-L738
+	//
+	initialismPairs = []string{
+		"Api", "API",
+		"Ascii", "ASCII",
+		"Cpu", "CPU",
+		"Css", "CSS",
+		"Dns", "DNS",
+		"Eof", "EOF",
+		"Guid", "GUID",
+		"Html", "HTML",
+		"Https", "HTTPS",
+		"Http", "HTTP",
+		"Id", "ID",
+		"Ip", "IP",
+		"Json", "JSON",
+		"Lhs", "LHS",
+		"Qps", "QPS",
+		"Ram", "RAM",
+		"Rhs", "RHS",
+		"Rpc", "RPC",
+		"Sla", "SLA",
+		"Smtp", "SMTP",
+		"Sql", "SQL",
+		"Ssh", "SSH",
+		"Tcp", "TCP",
+		"Tls", "TLS",
+		"Ttl", "TTL",
+		"Udp", "UDP",
+		"Uid", "UID",
+		"Ui", "UI",
+		"Uuid", "UUID",
+		"Uri", "URI",
+		"Url", "URL",
+		"Utf8", "UTF8",
+		"Vm", "VM",
+		"Xml", "XML",
+		"Xsrf", "XSRF",
+		"Xss", "XSS",
+	}
+
+	initialisms = strings.NewReplacer(initialismPairs...)
 )
 
 func init() {
@@ -90,4 +134,20 @@ func primitive(e *xmlElem) bool {
 		return true
 	}
 	return false
+}
+
+func lintName(s string) (should string) {
+	return squish(replace(s))
+}
+
+func title(s string) string {
+	return lintName(strings.Title(s))
+}
+
+func replace(s string) string {
+	return initialisms.Replace(s)
+}
+
+func squish(s string) string {
+	return strings.Replace(s, " ", "", -1)
 }

--- a/templ_test.go
+++ b/templ_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestTitle(t *testing.T) {
+	for i, tt := range []struct {
+		input, want string
+	}{
+		{"foo cpu baz", "FooCPUBaz"},
+		{"test Id", "TestID"},
+		{"json and html", "JSONAndHTML"},
+	} {
+		if got := title(tt.input); got != tt.want {
+			t.Errorf("[%d] title(%q) = %q, want %q", i, tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSquish(t *testing.T) {
+	for i, tt := range []struct {
+		input, want string
+	}{
+		{"Foo CPU Baz", "FooCPUBaz"},
+		{"Test ID", "TestID"},
+		{"JSON And HTML", "JSONAndHTML"},
+	} {
+		if got := squish(tt.input); got != tt.want {
+			t.Errorf("[%d] squish(%q) = %q, want %q", i, tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestReplace(t *testing.T) {
+	for i, tt := range []struct {
+		input, want string
+	}{
+		{"foo Cpu baz", "foo CPU baz"},
+		{"test Id", "test ID"},
+		{"Json and Html", "JSON and HTML"},
+	} {
+		if got := replace(tt.input); got != tt.want {
+			t.Errorf("[%d] replace(%q) = %q, want %q", i, tt.input, got, tt.want)
+		}
+	}
+
+	c := len(initialismPairs)
+
+	for i := 0; i < c; i++ {
+		input, want := initialismPairs[i], initialismPairs[i+1]
+
+		if got := replace(input); got != want {
+			t.Errorf("[%d] replace(%q) = %q, want %q", i, input, got, want)
+		}
+
+		i++
+	}
+}

--- a/xml_test.go
+++ b/xml_test.go
@@ -137,6 +137,33 @@ type tag struct {
 }
 			`,
 		},
+		{
+			`<schema>
+				<element name="tagId" type="tagReferenceType" />
+	<complexType name="tagReferenceType">
+		<simpleContent>
+			<extension base="string">
+				<attribute name="type" type="string" use="required" />
+			</extension>
+		</simpleContent>
+	</complexType>
+</schema>`,
+			xmlElem{
+				Name:  "tagId",
+				Type:  "string",
+				List:  false,
+				Cdata: true,
+				Attribs: []xmlAttrib{
+					{Name: "type", Type: "string"},
+				},
+			},
+			`
+type tagID struct {
+	Type string ` + "`xml:\"type,attr\"`" + `
+	TagID string ` + "`xml:\",chardata\"`" + `
+}
+			`,
+		},
 	}
 )
 


### PR DESCRIPTION
The initialism pairs are based on the `commonInitialisms` found in golang/lint
https://github.com/golang/lint/blob/4946cea8b6efd778dc31dc2dbeb919535e1b7529/lint.go#L698-L738