### PR TITLE
Implement omitempty

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -16,8 +16,8 @@ var (
 {{ end }}`
 
 	// Struct field generated from an element child element
-	child = `{{ define "Child" }}{{ printf "  %s " (lintTitle .Name) }}{{ if .List }}[]{{ end }}{{ printf "%s ` + "`xml:\\\"%s\\\"`" + `" (typeName (fieldType .)) .Name }}
-{{ end }}`
+	child = `{{ define "Child" }}{{ printf "  %s " (lintTitle .Name) }}{{ if .List }}[]{{ end }}{{ printf "%s ` + "`xml:\\\"%s%s\\\"`" + `" (typeName (fieldType .)) .Name (omitEmpty .OmitEmpty) }}
+	{{ end }}`
 
 	// Struct field generated from the character data of an element
 	cdata = `{{ define "Cdata" }}{{ printf "%s %s ` + "`xml:\\\",chardata\\\"`" + `" (lintTitle .Name) (lint .Type) }}
@@ -157,11 +157,20 @@ func prepareTemplates(prefix string, exported bool) (*template.Template, error) 
 		return name
 	}
 
+	omitEmpty := func(empty bool) string {
+		if !empty {
+			return ""
+		}
+
+		return ",omitempty"
+	}
+
 	fmap := template.FuncMap{
 		"lint":      lint,
 		"lintTitle": lintTitle,
 		"typeName":  typeName,
 		"fieldType": fieldType,
+		"omitEmpty": omitEmpty,
 	}
 
 	tt := template.New("yyy").Funcs(fmap)
@@ -187,6 +196,14 @@ func fieldType(e *xmlTree) string {
 		return e.Name
 	}
 	return e.Type
+}
+
+func omitEmpty(e *xmlTree) string {
+	if e.OmitEmpty {
+		return ",omitempty"
+	}
+
+	return ""
 }
 
 func primitiveType(e *xmlTree) bool {

--- a/goxsd.go
+++ b/goxsd.go
@@ -78,12 +78,13 @@ func main() {
 // - any attributes
 // - if the element contains any character data
 type xmlTree struct {
-	Name     string
-	Type     string
-	List     bool
-	Cdata    bool
-	Attribs  []xmlAttrib
-	Children []*xmlTree
+	Name      string
+	Type      string
+	List      bool
+	Cdata     bool
+	OmitEmpty bool
+	Attribs   []xmlAttrib
+	Children  []*xmlTree
 }
 
 type xmlAttrib struct {
@@ -138,6 +139,10 @@ func (b *builder) buildFromElement(e xsdElement) *xmlTree {
 
 	if e.isList() {
 		xelem.List = true
+	}
+
+	if e.omittable() {
+		xelem.OmitEmpty = true
 	}
 
 	if !e.inlineType() {
@@ -269,6 +274,7 @@ func (b *builder) buildFromAttributes(xelem *xmlTree, attrs []xsdAttribute) {
 			// that now
 			attr.Type = t
 		}
+
 		xelem.Attribs = append(xelem.Attribs, attr)
 	}
 }

--- a/goxsd.go
+++ b/goxsd.go
@@ -290,7 +290,7 @@ func (b *builder) findType(name string) interface{} {
 	switch name {
 	case "boolean":
 		return "bool"
-	case "language", "Name", "token", "duration", "anyURI":
+	case "language", "Name", "token", "duration", "anyURI", "normalizedString":
 		return "string"
 	case "long", "short", "integer", "int":
 		return "int"
@@ -298,7 +298,7 @@ func (b *builder) findType(name string) interface{} {
 		return "uint16"
 	case "decimal":
 		return "float64"
-	case "dateTime":
+	case "dateTime", "date":
 		return "time.Time"
 	default:
 		return name

--- a/goxsd_test.go
+++ b/goxsd_test.go
@@ -122,10 +122,11 @@ type title struct {
 				Type: "tagList",
 				Children: []*xmlTree{
 					&xmlTree{
-						Name:  "tag",
-						Type:  "string",
-						List:  true,
-						Cdata: true,
+						Name:      "tag",
+						Type:      "string",
+						List:      true,
+						Cdata:     true,
+						OmitEmpty: true,
 						Attribs: []xmlAttrib{
 							{Name: "type", Type: "string"},
 						},
@@ -134,7 +135,7 @@ type title struct {
 			},
 			gosrc: `
 type tagList struct {
-	Tag []tag ` + "`xml:\"tag\"`" + `
+	Tag []tag ` + "`xml:\"tag,omitempty\"`" + `
 }
 
 type tag struct {

--- a/xsd.go
+++ b/xsd.go
@@ -99,6 +99,10 @@ func (e xsdElement) isList() bool {
 	return e.Max == "unbounded"
 }
 
+func (e xsdElement) omittable() bool {
+	return e.Min == "0"
+}
+
 func (e xsdElement) inlineType() bool {
 	return e.Type == ""
 }


### PR DESCRIPTION
When child has an attribute: `minOccurs="0"`, append `, omitempty` to the Go struct tag.