### PR TITLE
Use float64 for xml double

### DIFF
--- a/goxsd.go
+++ b/goxsd.go
@@ -296,7 +296,7 @@ func (b *builder) findType(name string) interface{} {
 		return "int"
 	case "unsignedShort":
 		return "uint16"
-	case "decimal":
+	case "decimal","double":
 		return "float64"
 	case "dateTime":
 		return "time.Time"


### PR DESCRIPTION
The xml double type is specificed as a 64bit float so we should use the
go type float64 type when creating models.

http://books.xmlschemata.org/relaxng/ch19-77065.html