### PR TITLE
add iso-8859-1 decoding support

### DIFF
--- a/xsd.go
+++ b/xsd.go
@@ -31,6 +31,9 @@ func makeCharsetReader(charset string, input io.Reader) (io.Reader, error) {
 	if charset == "Windows-1252" {
 		return charmap.Windows1252.NewDecoder().Reader(input), nil
 	}
+	if charset === "iso-8859-1" {
+		return charmap.ISO8859_1.NewDecoder().Reader(input), nil
+	}
 	return nil, fmt.Errorf("Unknown charset: %s", charset)
 }
 


### PR DESCRIPTION
This follows #3.

I'm new to Go, so there might be problems with my code. 🙈 I want to use `goxsd` to generate a parser from the huge XSD tree at https://github.com/NeTEx-CEN/NeTEx/blob/master/xsd/NeTEx_publication.xsd